### PR TITLE
Demo App: Use vite .env file for dev:local in an OS-agnostic way

### DIFF
--- a/packages/demo/.env.dev-local
+++ b/packages/demo/.env.dev-local
@@ -1,0 +1,1 @@
+VITE_USE_MOCK_API=true

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev:local": "VITE_USE_MOCK_API=true vite",
-    "build:local": "tsc && VITE_USE_MOCK_API=true vite build",
-    "build": "tsc && VITE_USE_MOCK_API=true vite build",
+    "dev:local": "vite --mode dev-local",
+    "build:local": "tsc && vite build --mode dev-local",
+    "build": "tsc && vite build --mode dev-local",
     "preview:local": "VITE_USE_MOCK_API=true vite preview",
     "dev:remote": "VITE_USE_MOCK_API=false vite",
     "build:remote": "tsc && VITE_USE_MOCK_API=false vite build",


### PR DESCRIPTION
Currently the demo app's package.json uses a script for building and running the `dev:local` setup that doesn't work on windows because of the way that the "use mock api" flag is passed in. Rather than passing in that flag directly in the command, we can use [mode-specific environment variables](https://vite.dev/guide/env-and-mode.html#env-variables-and-modes).