### PR TITLE
Underline inline link for accessibility

### DIFF
--- a/packages/demo/src/components/Home.tsx
+++ b/packages/demo/src/components/Home.tsx
@@ -282,6 +282,7 @@ export default function Home(): JSX.Element {
               href="https://github.com/microsoft/Open-Source-Consent-Package"
               target="_blank"
               rel="noopener noreferrer"
+              className="inline-link"
             >
               Consent Package on GitHub
             </a>{' '}

--- a/packages/demo/src/main.css
+++ b/packages/demo/src/main.css
@@ -59,6 +59,10 @@ a:hover {
   color: var(--color-secondary);
 }
 
+a.inline-link {
+  text-decoration: underline;
+}
+
 .container {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
Align the demo app's home page with [link-in-text-block accessibility rule](https://dequeuniversity.com/rules/axe/4.10/link-in-text-block?application=axe-puppeteer) by ensuring it has an underline. This will make it distinguishable without relying on color.

<img width="942" height="54" alt="image" src="https://github.com/user-attachments/assets/7a3adc5e-5cd8-41ae-99aa-e85bdfbf5b2b" />
